### PR TITLE
fix: mark head and running volatile to fix data race in AudioReader

### DIFF
--- a/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioReader.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioReader.java
@@ -25,9 +25,9 @@ class AudioReader implements Runnable {
     private Stats available = StatsFactory.stats("Audio: Available");
     private byte[] audioChunk = new byte[CHUNK_SIZE];
     private final ByteBuffer gpuMapped;
-    private int head = 0;
+    private volatile int head = 0;
     private AudioDataSource mLine = null;
-    private boolean running = true;
+    private volatile boolean running = true;
     private final int audioTextureByteSize;
 
     public AudioReader(ByteBuffer gpuMapped, int audioTextureByteSize) {


### PR DESCRIPTION
Fixes the data race on `head` and `running` fields in `AudioReader` by marking them `volatile`.

Without `volatile`, the Java Memory Model provides no visibility guarantee between threads:
- `head` is written by the audio producer thread and read by the GL render thread
- `running` is written by the GL thread and read by the audio thread as a loop condition

Closes #4

Generated with [Claude Code](https://claude.ai/code)