### PR TITLE
Fix data race: make head and running volatile in AudioReader

### DIFF
--- a/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioReader.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioReader.java
@@ -25,9 +25,9 @@ class AudioReader implements Runnable {
     private Stats available = StatsFactory.stats("Audio: Available");
     private byte[] audioChunk = new byte[CHUNK_SIZE];
     private final ByteBuffer gpuMapped;
-    private int head = 0;
+    private volatile int head = 0;
     private AudioDataSource mLine = null;
-    private boolean running = true;
+    private volatile boolean running = true;
     private final int audioTextureByteSize;
 
     public AudioReader(ByteBuffer gpuMapped, int audioTextureByteSize) {


### PR DESCRIPTION
## Summary
- Mark `head` as `volatile int` — written by the audio thread, read by the GL render thread
- Mark `running` as `volatile boolean` — written by the GL thread (via `setRunning(false)`), read by the audio thread loop condition

Without `volatile`, the JMM makes no guarantee that either thread will ever observe writes made by the other. The audio thread may loop forever after dispose; the GL thread may see a stale write-head position.

## Changes
`AudioReader.java`: two field declarations changed to `volatile`.

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)