### PR TITLE
Fix off-by-one: reject experiments.size() as valid console index in ExperimentChooser

### DIFF
--- a/experiments/src/main/java/com/asteroid/duck/opengl/experiments/ExperimentChooser.java
+++ b/experiments/src/main/java/com/asteroid/duck/opengl/experiments/ExperimentChooser.java
@@ -179,7 +179,7 @@ public class ExperimentChooser implements Supplier<Experiment> {
 				} catch (NumberFormatException e) {
 					System.err.println("Invalid number, try again...");
 				}
-			} while (number < 0 || number > experiments.size());
+			} while (number < 0 || number >= experiments.size());
 			Experiment selected = experiments.get(number);
 			writeLastExperiment(selected);
 			return Optional.of(selected);


### PR DESCRIPTION
## Summary
`fromConsole()` displayed a 0-based menu `[0]`…`[N-1]` but accepted any value where `number <= experiments.size()`, meaning entering `N` passed the guard and then threw `IndexOutOfBoundsException` on `experiments.get(N)`.

Changed the loop condition from `number > experiments.size()` to `number >= experiments.size()` so `N` is correctly rejected as invalid input.

## Changes
`ExperimentChooser.java` line 191: `>` → `>=` in the do-while guard.

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)