### PR TITLE
Fix resource leak: properly dispose PBO, texture, VAO and join audio thread in AudioWave

### DIFF
--- a/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioWave.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioWave.java
@@ -70,6 +70,7 @@ public class AudioWave implements RenderedItem {
     private Uniform<Integer> uHead;
 
     private AudioReader audioReader;
+    private Thread audioReaderThread;
 
 
     @Override
@@ -85,8 +86,9 @@ public class AudioWave implements RenderedItem {
 
         // Start a Producer thread to continuously fill the GPU buffer with audio data
         this.audioReader = new AudioReader(gpuMapped, AUDIO_TEXTURE_BYTE_SIZE);
-        Thread audioReaderThread = new Thread(audioReader);
-        audioReaderThread.start();
+        this.audioReaderThread = new Thread(audioReader, "audio-reader");
+        this.audioReaderThread.setDaemon(true);
+        this.audioReaderThread.start();
         glLineWidth(6.0f);
         ctx.setDesiredUpdateFrequency(60.0);
     }
@@ -227,8 +229,23 @@ public class AudioWave implements RenderedItem {
 
     @Override
     public void dispose() {
+        // Signal the audio thread to stop and unblock it if it is waiting for a line
         audioReader.setRunning(false);
+        audioReader.setLine(null);
+        try {
+            if (audioReaderThread != null) {
+                audioReaderThread.join(2000);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        // Release GL resources in reverse-init order
+        vao.dispose();
         shader.dispose();
+        glDeleteBuffers(pboId);
+        glDeleteTextures(audioTextureId);
+        pboId = 0;
+        audioTextureId = 0;
     }
 
     public void setLineWidth(float v) {


### PR DESCRIPTION
## Summary
- `dispose()` now deletes the PBO (`glDeleteBuffers`), the 1-D audio texture (`glDeleteTextures`), and the VAO (`vao.dispose()`) in addition to the shader
- The audio reader thread is stored as a field (`audioReaderThread`) so `dispose()` can join it (with a 2 s timeout) before releasing the GPU-mapped buffer it writes to
- `audioReader.setLine(null)` is called before joining to unblock the thread if it is waiting in `waitForLine()`
- Thread is named `"audio-reader"` and marked daemon so it cannot prevent JVM shutdown

## Changes
`AudioWave.java`: new `audioReaderThread` field; updated thread creation in `init()`; replaced `dispose()` body.

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)