### PR TITLE
Fix build/config: remove dead x2 variable, make simulate.audio explicit

### DIFF
--- a/core/src/main/java/com/asteroid/duck/opengl/util/audio/LineAcquirer.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/audio/LineAcquirer.java
@@ -21,7 +21,7 @@ public class LineAcquirer {
   private int selectedSource = 0;
 
   public void init(RenderContext ctx, AudioFormat ideal)  {
-    if (System.getProperty("simulate.audio", "true").equalsIgnoreCase("true")) {
+    if (System.getProperty("simulate.audio", "false").equalsIgnoreCase("true")) {
       StereoDataSource audio = getSampledWaveformData();
       sources.add(new SimulatedDataSource(ctx.getTimer(), audio));
     }

--- a/experiments/build.gradle
+++ b/experiments/build.gradle
@@ -27,6 +27,7 @@ application {
 
 tasks.named('run', JavaExec) {
     systemProperty "slf4j.internal.verbosity", "WARN"
+    systemProperty "simulate.audio", "true"
     environment += [
             '__NV_PRIME_RENDER_OFFLOAD'  : '1',
             '__GLX_VENDOR_LIBRARY_NAME'  : 'nvidia',
@@ -41,7 +42,6 @@ tasks.named('startScripts', CreateStartScripts) {
                        '__GLX_VENDOR_LIBRARY_NAME=nvidia',
                        '__GL_THREADED_OPTIMIZATIONS=0']
         def envVarsScript = envVars.collect { "export ${it}" }.join('\n')
-        def x2 = 'export APP_MODE=production\nexport LOG_LEVEL=debug'
         // Inject them right after the shebang or near the top of the script
         final HEADER = '#!/bin/sh'
         unixScript.text = unixScript.text.replace(HEADER, HEADER + "\n\n${envVarsScript}")


### PR DESCRIPTION
## Summary

- **#14** Removed the unused local variable `x2` from the `startScripts` `doLast` block in `experiments/build.gradle`. It was defined but never referenced anywhere.

- **#15** `LineAcquirer.init()` defaulted `simulate.audio` to `"true"`, silently prepending a `SimulatedDataSource` to the source list in all run modes unless explicitly overridden. Changed the code-level default to `"false"` (real hardware is the right default for production). Added an explicit `systemProperty "simulate.audio", "true"` to the `run` task so the development-time opt-in is visible and intentional.

## Files changed
- `experiments/build.gradle` — removed `x2` line; added `systemProperty "simulate.audio", "true"` to the `run` task
- `core/.../audio/LineAcquirer.java` — default for `simulate.audio` changed from `"true"` to `"false"`

Fixes #14
Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/claude-code)