### PR TITLE
Fix parameter shadowing: rename limit to length in SimulatedDataSource.read()

### DIFF
--- a/core/src/main/java/com/asteroid/duck/opengl/util/audio/AudioDataSource.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/audio/AudioDataSource.java
@@ -32,10 +32,10 @@ public interface AudioDataSource {
 	 * Read raw audio data into the given array
 	 * @param array the array to read into
 	 * @param start start index in the array, the first byte read will go here
-	 * @param limit maximum number of bytes to read
+	 * @param length maximum number of bytes to read
 	 * @return number of bytes actually read
 	 */
-	int read(byte[] array, int start, int limit);
+	int read(byte[] array, int start, int length);
 	/**
 	 * Stop the data source (can be restarted)
 	 */

--- a/core/src/main/java/com/asteroid/duck/opengl/util/audio/simulated/SimulatedDataSource.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/audio/simulated/SimulatedDataSource.java
@@ -62,7 +62,7 @@ public class SimulatedDataSource implements AudioDataSource {
 	}
 
 	@Override
-	public int read(byte[] array, int start, int limit) {
+	public int read(byte[] array, int start, int length) {
 		double now = timer.elapsed();
 		double samplePeriod = 1.0 / format.getSampleRate();
 		// this is the maximum number of samples we can read (respecting our buffer limit)
@@ -70,8 +70,8 @@ public class SimulatedDataSource implements AudioDataSource {
 		if (samples <= 0)
 			return 0;
 
-		// this buffer is a short view onto the array calibrated to the start and limit given
-		ShortBuffer buffer = ByteBuffer.wrap(array, start, limit).order(ByteOrder.LITTLE_ENDIAN).asShortBuffer();
+		// this buffer is a short view onto the array calibrated to the start and length given
+		ShortBuffer buffer = ByteBuffer.wrap(array, start, length).order(ByteOrder.LITTLE_ENDIAN).asShortBuffer();
 
 		// Can the buffer take more than we can theoretically read
 		if (buffer.remaining() > samples) {


### PR DESCRIPTION
## Summary

`SimulatedDataSource.read(byte[], int, int limit)` had a parameter named `limit` that shadowed the instance field `this.limit`. The two mean different things: the field is the buffer capacity set via `open()`; the parameter is the read byte count requested by the caller. Renamed the parameter to `length` to match the `java.io.InputStream` convention and eliminate the shadowing.

## Files changed
- `core/.../simulated/SimulatedDataSource.java` — parameter renamed in method signature and body
- `core/.../audio/AudioDataSource.java` — interface parameter name updated for consistency

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/claude-code)