### PR TITLE
fix: AudioWave register PBO and audio texture with ResourceManager (issue #7)

### DIFF
--- a/core/src/main/java/com/asteroid/duck/opengl/util/resources/manager/ResourceManager.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/resources/manager/ResourceManager.java
@@ -40,4 +40,13 @@ public interface ResourceManager extends Resource, BindingContext {
 	TextureUnit nextTextureUnit();
 	Stream<TextureUnit> textureUnits();
 
+	/**
+	 * Register an arbitrary resource for lifecycle tracking. The resource's {@code dispose()}
+	 * will be called when this manager is disposed, ensuring cleanup even for resources that
+	 * don't fit into a named category (textures, shaders, texture units).
+	 *
+	 * @param resource the resource to track; null values are ignored
+	 */
+	void register(Resource resource);
+
 }

--- a/core/src/main/java/com/asteroid/duck/opengl/util/resources/manager/ResourceManagerImpl.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/resources/manager/ResourceManagerImpl.java
@@ -38,6 +38,8 @@ public class ResourceManagerImpl implements Resource, ResourceManager {
 	private final NamedResourceManager<Texture> textures = new NamedResourceManager<>();
 	private final NamedResourceManager<ShaderProgram> shaders = new NamedResourceManager<>();
 	private final NamedResourceManager<TextureUnit> textureUnits = new NamedResourceManager<>();
+	// catch-all for resources that don't fit a named category
+	private final ResourceListManager<Resource> others = new ResourceListManager<>();
 
 	private final SortedSet<Integer> unallocatedTextureUnits = new TreeSet<>();
 
@@ -192,6 +194,11 @@ public class ResourceManagerImpl implements Resource, ResourceManager {
 		return group;
 	}
 
+	@Override
+	public void register(Resource resource) {
+		others.add(resource);
+	}
+
 	/**
 	 * Destroy and clear all managed resources. After calling this method the manager will have no cached resources.
 	 *
@@ -204,6 +211,7 @@ public class ResourceManagerImpl implements Resource, ResourceManager {
 		textures.dispose();
 		shaders.dispose();
 		textureUnits.dispose();
+		others.dispose();
 
 		initTextureUnits();
 	}

--- a/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioWave.java
+++ b/core/src/main/java/com/asteroid/duck/opengl/util/wave/AudioWave.java
@@ -225,6 +225,7 @@ public class AudioWave implements RenderedItem {
 
     private ByteBuffer initAudioBuffer(RenderContext ctx) {
         this.audioTextureId = glGenTextures();
+        // Raw bind: GL_TEXTURE_1D is not yet covered by an ExclusivityGroup in this project.
         glBindTexture(GL_TEXTURE_1D, audioTextureId);
 
         // 1. Set Wrapping to REPEAT so the uHead offset wraps automatically
@@ -241,7 +242,9 @@ public class AudioWave implements RenderedItem {
         glBindTexture(GL_TEXTURE_1D, 0);
 
 
-        // 1. Create a Pixel Buffer Object (PBO)
+        // Raw bind: the PBO uses GL44 persistent mapping (GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT),
+        // which requires glBufferStorage and a single persistent map for the audio producer thread.
+        // This doesn't fit the existing VertexBufferObject abstraction, so we manage it directly.
         this.pboId = glGenBuffers();
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pboId);
 
@@ -250,7 +253,16 @@ public class AudioWave implements RenderedItem {
         glBufferStorage(GL_PIXEL_UNPACK_BUFFER, AUDIO_TEXTURE_BYTE_SIZE, flags);
 
         // 3. Map it once and keep the reference
-        return glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, AUDIO_TEXTURE_BYTE_SIZE, flags);
+        ByteBuffer mapped = glMapBufferRange(GL_PIXEL_UNPACK_BUFFER, 0, AUDIO_TEXTURE_BYTE_SIZE, flags);
+
+        // Register both raw GL resources with the ResourceManager so they are lifecycle-tracked
+        // and cleaned up on shutdown even if dispose() is not called directly.
+        ctx.getResourceManager().register(() -> {
+            glDeleteTextures(audioTextureId);
+            glDeleteBuffers(pboId);
+        });
+
+        return mapped;
     }
 
     @Override


### PR DESCRIPTION
Addresses #7.

Registers the raw GL audio texture and PBO created by `AudioWave` with `ResourceManager` for lifecycle tracking, using a new `register(Resource)` API. Also adds comments explaining why the bindings remain raw.

See the PR description and commit message for full details.

Generated with [Claude Code](https://claude.ai/code)